### PR TITLE
Add LFS integrity check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ The following Bash scripts mirror the PowerShell ones:
 - `coordinate-repo-cleaning.sh` – orchestrate all steps
 
 Check each script for usage details. The repository intentionally omits persistent archives; after running, push the sanitized repo to a new remote and store binary artifacts in GCS.
+
+## PowerShell utilities
+
+- `check-lfs-integrity.ps1` – verify that all LFS objects referenced in the repository exist on the server

--- a/check-lfs-integrity.ps1
+++ b/check-lfs-integrity.ps1
@@ -1,0 +1,15 @@
+param(
+    [switch]$Verbose
+)
+
+$fsckOutput = git lfs fsck 2>&1
+$missing = $fsckOutput | Select-String "Object does not exist on the server"
+
+if ($missing) {
+    Write-Host "Missing LFS objects detected:" -ForegroundColor Red
+    $missing | ForEach-Object { Write-Host $_.Line }
+    exit 1
+} else {
+    Write-Host "No missing LFS objects found."
+    exit 0
+}


### PR DESCRIPTION
## Summary
- add `check-lfs-integrity.ps1` to verify missing Git LFS objects
- document the new PowerShell utility in the README

## Testing
- `git lfs fsck`
- `pwsh -Command ./check-lfs-integrity.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cdf219fdc832a87b0c145f7fb61fa