### PR TITLE
Add LFS guard installation to cleanup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ Check each script for usage details. The repository intentionally omits persiste
 ## PowerShell utilities
 
 - `check-lfs-integrity.ps1` – verify that all LFS objects referenced in the repository exist on the server
+
+## LFS Guard
+
+All scripts now place a `.lfs.guard` file and a pre-commit hook into generated repositories and manifest folders. The guard includes a SHA-256 hash of the current manifest so clones can verify integrity and will block any attempt to commit Git LFS objects.

--- a/build-lfs-manifest.ps1
+++ b/build-lfs-manifest.ps1
@@ -79,3 +79,4 @@ if (Test-Path $TemplatePath) {
 }
 
 Write-Host "Manifest files generated for $RepoName in $ManifestPath"
+& "$(Join-Path $PSScriptRoot 'install-lfs-guard.ps1')" -TargetPath $ManifestPath -ManifestYaml $ManifestYaml

--- a/build-lfs-manifest.sh
+++ b/build-lfs-manifest.sh
@@ -59,3 +59,6 @@ if [ -f "$template_path" ]; then
 else
   echo "No HTML template found at $template_path"
 fi
+
+# Place LFS guard and hook in manifest directory
+"$(dirname "$0")"/install-lfs-guard.sh "$manifest_path" "$manifest_yaml"

--- a/install-lfs-guard.ps1
+++ b/install-lfs-guard.ps1
@@ -1,0 +1,31 @@
+param(
+    [string]$TargetPath,
+    [string]$ManifestYaml = ""
+)
+
+if (-not $TargetPath) {
+    Write-Error "TargetPath is required"
+    exit 1
+}
+
+$hash = "N/A"
+if ($ManifestYaml -and (Test-Path $ManifestYaml)) {
+    $hash = (Get-FileHash -Algorithm SHA256 $ManifestYaml).Hash
+}
+
+$guardFile = Join-Path $TargetPath ".lfs.guard"
+"This repository has had Git LFS removed. Reintroducing LFS is prohibited.`nManifest SHA256: $hash" | Set-Content -Path $guardFile
+
+$hookDir = Join-Path $TargetPath ".git/hooks"
+if (-not (Test-Path $hookDir)) { New-Item -ItemType Directory -Path $hookDir | Out-Null }
+$preCommit = Join-Path $hookDir "pre-commit"
+$hookContent = @'
+#!/usr/bin/env bash
+if git lfs ls-files | grep -q .; then
+  echo "❌ LFS usage is prohibited in this repo."
+  exit 1
+fi
+'@
+$hookContent | Set-Content -Path $preCommit -NoNewline
+try { icacls $preCommit /grant Everyone:RX > $null } catch {}
+

--- a/install-lfs-guard.sh
+++ b/install-lfs-guard.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <target_path> [manifest_yaml]" >&2
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+target="$1"
+manifest="${2:-}"
+
+hash="N/A"
+if [[ -n "$manifest" && -f "$manifest" ]]; then
+  hash=$(sha256sum "$manifest" | awk '{print $1}')
+fi
+
+mkdir -p "$target"
+cat > "$target/.lfs.guard" <<EOF2
+This repository has had Git LFS removed. Reintroducing LFS is prohibited.
+Manifest SHA256: $hash
+EOF2
+
+hook_dir="$target/.git/hooks"
+mkdir -p "$hook_dir"
+cat > "$hook_dir/pre-commit" <<'HOOK'
+#!/usr/bin/env bash
+if git lfs ls-files | grep -q .; then
+  echo "❌ LFS usage is prohibited in this repo."
+  exit 1
+fi
+HOOK
+chmod +x "$hook_dir/pre-commit"
+

--- a/prepare-speaktome.ps1
+++ b/prepare-speaktome.ps1
@@ -17,3 +17,4 @@ Set-Location $TargetPath
 
 
 Write-Host "Repository prepared at $TargetPath"
+& "$(Join-Path $PSScriptRoot 'install-lfs-guard.ps1')" -TargetPath $TargetPath

--- a/prepare-speaktome.sh
+++ b/prepare-speaktome.sh
@@ -15,3 +15,6 @@ git clone "$repo_url" "$target_path" --config filter.lfs.smudge= --config filter
 cd "$target_path"
 
 echo "Repository prepared at $target_path"
+
+# Install guard to prevent accidental LFS usage
+"$(dirname "$0")"/install-lfs-guard.sh "$target_path"

--- a/reinstall-clean-repo.ps1
+++ b/reinstall-clean-repo.ps1
@@ -18,6 +18,9 @@ Set-Location $CleanPath
 git config --local filter.lfs.smudge ""
 git config --local filter.lfs.required false
 
+# Place guard file and pre-commit hook
+& "$(Join-Path $PSScriptRoot 'install-lfs-guard.ps1')" -TargetPath $CleanPath
+
 # Emergency manual hold
 Write-Host "`nEMERGENCY MODE: Review the repo state before overwriting remote."
 Write-Host "Press Enter to continue with FORCE PUSH or Ctrl+C to cancel."

--- a/reinstall-clean-repo.sh
+++ b/reinstall-clean-repo.sh
@@ -13,6 +13,9 @@ cd "$clean_path"
 git config --local filter.lfs.smudge ""
 git config --local filter.lfs.required false
 
+# Insert LFS guard and hook
+"$(dirname "$0")"/install-lfs-guard.sh "$clean_path"
+
 echo -e "\nEMERGENCY MODE: Review the repo state before overwriting remote."
 read -p "Press Enter to continue with FORCE PUSH or Ctrl+C to cancel" _
 


### PR DESCRIPTION
## Summary
- guard cleaned repos and manifests with `.lfs.guard`
- add pre-commit hook to detect accidental LFS usage
- integrate guard installation into prepare, reinstall, and manifest scripts
- document the guard feature

## Testing
- `bash install-lfs-guard.sh testguard`
- `bash -n prepare-speaktome.sh`
- `bash -n reinstall-clean-repo.sh`
- `bash -n build-lfs-manifest.sh`
- `pwsh` not available to validate PowerShell scripts

------
https://chatgpt.com/codex/tasks/task_e_684ce08dbf08832a8c71d94e738d4232