### PR TITLE
Add dry run and manifest logging features

### DIFF
--- a/build-lfs-manifest.ps1
+++ b/build-lfs-manifest.ps1
@@ -26,11 +26,16 @@ $TemplatePath    = Join-Path $BasePath "template\feed.html"  # Optional
 $ManifestYaml    = Join-Path $ManifestPath "lfs_manifest.yaml"
 $ManifestMD      = Join-Path $ManifestPath "lfs_manifest.md"
 $ManifestHTML    = Join-Path $ManifestPath "index.html"
+$LogFile         = Join-Path $ManifestPath "manifest.log"
+
+if (-not (Test-Path $LogFile)) { New-Item -ItemType File -Path $LogFile | Out-Null }
+"$(Get-Date -Format s) Starting manifest generation" | Add-Content -Path $LogFile
 
 # === Ensure directories exist ===
 @($QuarantinePath, $ManifestPath) | ForEach-Object {
     if (-not (Test-Path $_)) { New-Item -ItemType Directory -Path $_ | Out-Null }
 }
+"$(Get-Date -Format s) Directories ensured" | Add-Content -Path $LogFile
 
 # === Scan quarantined LFS files ===
 $Files = Get-ChildItem -Recurse -Path $QuarantinePath | Where-Object { -not $_.PSIsContainer }
@@ -53,6 +58,7 @@ foreach ($file in $Files) {
 }
 
 $YamlData | ConvertTo-Yaml | Set-Content -Path $ManifestYaml
+"$(Get-Date -Format s) YAML manifest saved to $ManifestYaml" | Add-Content -Path $LogFile
 
 # === Generate Markdown ===
 $Markdown = @(
@@ -65,6 +71,7 @@ $Markdown += $Files | ForEach-Object {
     "| `$_` | $($_.Length) | $($_.LastWriteTime.ToString('u')) |"
 }
 $Markdown -join "`n" | Set-Content -Path $ManifestMD
+"$(Get-Date -Format s) Markdown manifest saved to $ManifestMD" | Add-Content -Path $LogFile
 
 # === Optional: Generate HTML ===
 if (Test-Path $TemplatePath) {
@@ -74,9 +81,12 @@ if (Test-Path $TemplatePath) {
     } | Out-String
     $HtmlFinal = $HtmlTemplate -replace "{{file_rows}}", $FileRows
     $HtmlFinal | Set-Content -Path $ManifestHTML
+    "$(Get-Date -Format s) HTML manifest saved to $ManifestHTML" | Add-Content -Path $LogFile
 } else {
     Write-Warning "No HTML template found at $TemplatePath"
+    "$(Get-Date -Format s) No HTML template found" | Add-Content -Path $LogFile
 }
 
 Write-Host "Manifest files generated for $RepoName in $ManifestPath"
+"$(Get-Date -Format s) Manifest generation complete" | Add-Content -Path $LogFile
 & "$(Join-Path $PSScriptRoot 'install-lfs-guard.ps1')" -TargetPath $ManifestPath -ManifestYaml $ManifestYaml

--- a/install-lfs-guard.ps1
+++ b/install-lfs-guard.ps1
@@ -20,7 +20,17 @@ $hookDir = Join-Path $TargetPath ".git/hooks"
 if (-not (Test-Path $hookDir)) { New-Item -ItemType Directory -Path $hookDir | Out-Null }
 $preCommit = Join-Path $hookDir "pre-commit"
 $sourceHook = Join-Path $PSScriptRoot "pre-commit.lfs.guard"
-Copy-Item $sourceHook $preCommit -Force
+    Copy-Item $sourceHook $preCommit -Force
 
-try { icacls $preCommit /grant Everyone:RX > $null } catch {}
+    try { icacls $preCommit /grant Everyone:RX > $null } catch {}
+
+    # Lock the pre-commit hook to prevent modification
+    Set-ItemProperty -Path $preCommit -Name IsReadOnly -Value $true
+
+    # Ensure .gitattributes exists and is read-only to discourage LFS usage
+    $gitAttr = Join-Path $TargetPath '.gitattributes'
+    if (-not (Test-Path $gitAttr)) {
+        New-Item -ItemType File -Path $gitAttr | Out-Null
+    }
+    Set-ItemProperty -Path $gitAttr -Name IsReadOnly -Value $true
 

--- a/reinstall-clean-repo.ps1
+++ b/reinstall-clean-repo.ps1
@@ -7,11 +7,23 @@ param (
 
     [ValidateNotNullOrEmpty()]
     [string]$RemoteURL  # Remote URL for the repository
+
+    [switch]$WhatIf
 )
 
 # Clean destination if exists
-if (Test-Path $CleanPath) { Remove-Item -Recurse -Force $CleanPath }
-Copy-Item -Recurse -Force $RepoPath $CleanPath
+if (Test-Path $CleanPath) {
+    if ($WhatIf) {
+        Write-Host "[WhatIf] Would remove $CleanPath" -ForegroundColor Yellow
+    } else {
+        Remove-Item -Recurse -Force $CleanPath
+    }
+}
+if ($WhatIf) {
+    Write-Host "[WhatIf] Would copy $RepoPath to $CleanPath" -ForegroundColor Yellow
+} else {
+    Copy-Item -Recurse -Force $RepoPath $CleanPath
+}
 
 Set-Location $CleanPath
 # Ensure Git operates without LFS filters
@@ -22,10 +34,18 @@ git config --local filter.lfs.required false
 & "$(Join-Path $PSScriptRoot 'install-lfs-guard.ps1')" -TargetPath $CleanPath
 
 # Emergency manual hold
-Write-Host "`nEMERGENCY MODE: Review the repo state before overwriting remote."
-Write-Host "Press Enter to continue with FORCE PUSH or Ctrl+C to cancel."
-Read-Host
+if (-not $WhatIf) {
+    Write-Host "`nEMERGENCY MODE: Review the repo state before overwriting remote."
+    Write-Host "Press Enter to continue with FORCE PUSH or Ctrl+C to cancel."
+    Read-Host
+} else {
+    Write-Host "[WhatIf] Skipping interactive confirmation" -ForegroundColor Yellow
+}
 
 # Force push to clean overwrite the repo (use carefully)
 git remote set-url origin $RemoteURL
-git push --force --set-upstream origin main
+if ($WhatIf) {
+    Write-Host "[WhatIf] Would force push to $RemoteURL" -ForegroundColor Yellow
+} else {
+    git push --force --set-upstream origin main
+}


### PR DESCRIPTION
## Summary
- lock `.gitattributes` and pre-commit hook in `install-lfs-guard.ps1`
- support `-WhatIf` mode in `reinstall-clean-repo.ps1`
- log manifest generation steps in `build-lfs-manifest.ps1`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cf91ec008832ab8f7c91d0d1c1df9