### PR TITLE
Add gsutil availability checks

### DIFF
--- a/upload-lfs-to-gcs.ps1
+++ b/upload-lfs-to-gcs.ps1
@@ -15,9 +15,9 @@ if (-not (Test-Path $GCloudKeyPath)) {
 
 $env:GOOGLE_APPLICATION_CREDENTIALS = $GCloudKeyPath
 
-if (-not (Test-Path $QuarantinePath)) {
-    Write-Warning "Quarantine path not found: $QuarantinePath"
-    exit 0
+if (-not (Get-Command gsutil -ErrorAction SilentlyContinue)) {
+    Write-Error "gsutil not found in PATH"
+    exit 1
 }
 
 if (-not (Test-Path $QuarantinePath)) {
@@ -29,7 +29,7 @@ Get-ChildItem -Recurse -Path $QuarantinePath -Include $IncludeExtensions | ForEa
     $RelativePath = $_.FullName.Substring($QuarantinePath.Length).TrimStart('\')
     $GcsPath = "$GCSBucket/$RelativePath".Replace('\\', '/')
     Write-Host "Uploading $($_.Name) to $GcsPath"
-    Invoke-CheckedCommand -WhatIf:$WhatIf -Command { gsutil cp $_.FullName $GcsPath }
+    Invoke-CheckedCommand -WhatIf:$WhatIf -Command { gsutil cp -- "$_.FullName" "$GcsPath" }
 }
 
 $skipped = Get-ChildItem -Recurse -Path $QuarantinePath | Where-Object { $_.Extension -notin $IncludeExtensions }

--- a/upload-lfs-to-gcs.sh
+++ b/upload-lfs-to-gcs.sh
@@ -12,13 +12,18 @@ fi
 
 export GOOGLE_APPLICATION_CREDENTIALS="$gcloud_key_path"
 
+if ! command -v gsutil >/dev/null 2>&1; then
+  echo "gsutil not found in PATH" >&2
+  exit 1
+fi
+
 if [ ! -d "$quarantine_path" ]; then
   echo "Quarantine path not found: $quarantine_path"
   exit 0
 fi
 
 find "$quarantine_path" -type f -name '*.whl' | while read -r file; do
-  rel="${file#$quarantine_path/}"
+  rel="${file#"$quarantine_path"/}"
   gcs_path="$gcs_bucket/$rel"
   echo "Uploading $file to $gcs_path"
   gsutil cp "$file" "$gcs_path"


### PR DESCRIPTION
## Summary
- check that `gsutil` is on `PATH` before uploading
- same check for PowerShell version

## Testing
- `shellcheck upload-lfs-to-gcs.sh`
- `shellcheck coordinate-repo-cleaning.sh` *(fails: SC1091 info)*
- ❌ `pwsh -c 'Write-Host test'` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db95233c8832aade383a2e1b4dabc